### PR TITLE
feat(light-controller): add lightGroup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ Also this card will detect these icons installed and will use them prior to HA i
     </td>
   </tr>
   <tr>
+    <td><code>groupEntity</code></td>
+    <td>string</td>
+    <td>no</td>
+    <td>1.6.0</td>
+    <td>-</td>
+    <td><b>Light</b> entity ID that represents the group of light entities (eg. <code>light.my_light_group</code>). This is useful for some platforms like hue which provide an entity representing the room, in addition to the individual light entities. This can be defined to toggle the lights all at once, rather than successively.</td>
+  </tr>
+  <tr>
     <td><code>title</code></td>
     <td><a href="#text-template">Text Template</a></td>
     <td>no</td>

--- a/src/core/light-controller.ts
+++ b/src/core/light-controller.ts
@@ -12,12 +12,12 @@ import { localize } from '../localize/localize';
 
 export class LightController extends NotifyBase<LightController> implements ILightContainer {
     private _hass: HomeAssistant;
-    private _lightGroupEntity: LightContainer | undefined;
+    private _lightGroup?: LightContainer;
     private _lights: LightContainer[];
     private _lightsFeatures: LightFeaturesCombined;
     private _defaultColor: Color;
 
-    public constructor(entity_ids: string[], defaultColor: Color, _lightGroupEntityId: string | undefined) {
+    public constructor(entity_ids: string[], defaultColor: Color, lightGroupEntityId?: string) {
         super();
 
         // we need at least one
@@ -27,8 +27,8 @@ export class LightController extends NotifyBase<LightController> implements ILig
         this._defaultColor = defaultColor;
         this._lights = entity_ids.map(e => GlobalLights.getLightContainer(e));
         this._lightsFeatures = new LightFeaturesCombined(() => this._lights.map(l => l.features));
-        if (_lightGroupEntityId !== undefined) {
-            this._lightGroupEntity = GlobalLights.getLightContainer(_lightGroupEntityId);
+        if (lightGroupEntityId) {
+            this._lightGroup = GlobalLights.getLightContainer(lightGroupEntityId);
         }
     }
 
@@ -56,8 +56,8 @@ export class LightController extends NotifyBase<LightController> implements ILig
     public set hass(hass: HomeAssistant) {
         this._hass = hass;
         this._lights.forEach(l => l.hass = hass);
-        if (this._lightGroupEntity != undefined) {
-            this._lightGroupEntity.hass = hass;
+        if (this._lightGroup) {
+            this._lightGroup.hass = hass;
         }
         this.raisePropertyChanged('hass');
     }
@@ -66,32 +66,32 @@ export class LightController extends NotifyBase<LightController> implements ILig
     }
 
     public isOn(): boolean {
-        if (this._lightGroupEntity != undefined) {
-            return this._lightGroupEntity.isOn();
+        if (this._lightGroup) {
+            return this._lightGroup.isOn();
         }
         return this._lights.some(l => l.isOn());
     }
     public isOff(): boolean {
-        if (this._lightGroupEntity != undefined) {
-            return this._lightGroupEntity.isOff();
+        if (this._lightGroup) {
+            return this._lightGroup.isOff();
         }
         return this._lights.every(l => l.isOff());
     }
     public isUnavailable(): boolean {
-        if (this._lightGroupEntity != undefined) {
-            return this._lightGroupEntity.isUnavailable();
+        if (this._lightGroup) {
+            return this._lightGroup.isUnavailable();
         }
         return this._lights.every(l => l.isUnavailable());
     }
     public turnOn(): void {
-        if (this._lightGroupEntity != undefined) {
-            return this._lightGroupEntity.turnOn();
+        if (this._lightGroup) {
+            return this._lightGroup.turnOn();
         }
         this._lights.filter(l => l.isOff()).forEach(l => l.turnOn());
     }
     public turnOff(): void {
-        if (this._lightGroupEntity != undefined) {
-            return this._lightGroupEntity.turnOff();
+        if (this._lightGroup) {
+            return this._lightGroup.turnOff();
         }
         this._lights.filter(l => l.isOn()).forEach(l => l.turnOff());
     }
@@ -167,8 +167,8 @@ export class LightController extends NotifyBase<LightController> implements ILig
     }
 
     public getTitle() {
-        if (this._lightGroupEntity != undefined) {
-            return this._lightGroupEntity.getTitle();
+        if (this._lightGroup) {
+            return this._lightGroup.getTitle();
         }
 
         let title = '';

--- a/src/core/light-controller.ts
+++ b/src/core/light-controller.ts
@@ -12,11 +12,12 @@ import { localize } from '../localize/localize';
 
 export class LightController extends NotifyBase<LightController> implements ILightContainer {
     private _hass: HomeAssistant;
+    private _lightGroupEntity: LightContainer | undefined;
     private _lights: LightContainer[];
     private _lightsFeatures: LightFeaturesCombined;
     private _defaultColor: Color;
 
-    public constructor(entity_ids: string[], defaultColor: Color) {
+    public constructor(entity_ids: string[], defaultColor: Color, _lightGroupEntityId: string | undefined) {
         super();
 
         // we need at least one
@@ -26,6 +27,9 @@ export class LightController extends NotifyBase<LightController> implements ILig
         this._defaultColor = defaultColor;
         this._lights = entity_ids.map(e => GlobalLights.getLightContainer(e));
         this._lightsFeatures = new LightFeaturesCombined(() => this._lights.map(l => l.features));
+        if (_lightGroupEntityId !== undefined) {
+            this._lightGroupEntity = GlobalLights.getLightContainer(_lightGroupEntityId);
+        }
     }
 
     /**
@@ -52,6 +56,9 @@ export class LightController extends NotifyBase<LightController> implements ILig
     public set hass(hass: HomeAssistant) {
         this._hass = hass;
         this._lights.forEach(l => l.hass = hass);
+        if (this._lightGroupEntity != undefined) {
+            this._lightGroupEntity.hass = hass;
+        }
         this.raisePropertyChanged('hass');
     }
     public get hass() {
@@ -59,18 +66,33 @@ export class LightController extends NotifyBase<LightController> implements ILig
     }
 
     public isOn(): boolean {
+        if (this._lightGroupEntity != undefined) {
+            return this._lightGroupEntity.isOn();
+        }
         return this._lights.some(l => l.isOn());
     }
     public isOff(): boolean {
+        if (this._lightGroupEntity != undefined) {
+            return this._lightGroupEntity.isOff();
+        }
         return this._lights.every(l => l.isOff());
     }
     public isUnavailable(): boolean {
+        if (this._lightGroupEntity != undefined) {
+            return this._lightGroupEntity.isUnavailable();
+        }
         return this._lights.every(l => l.isUnavailable());
     }
     public turnOn(): void {
+        if (this._lightGroupEntity != undefined) {
+            return this._lightGroupEntity.turnOn();
+        }
         this._lights.filter(l => l.isOff()).forEach(l => l.turnOn());
     }
     public turnOff(): void {
+        if (this._lightGroupEntity != undefined) {
+            return this._lightGroupEntity.turnOff();
+        }
         this._lights.filter(l => l.isOn()).forEach(l => l.turnOff());
     }
 
@@ -145,6 +167,10 @@ export class LightController extends NotifyBase<LightController> implements ILig
     }
 
     public getTitle() {
+        if (this._lightGroupEntity != undefined) {
+            return this._lightGroupEntity.getTitle();
+        }
+
         let title = '';
         for (let i = 0; i < this._lights.length && i < 3; i++) {
             if (i > 0) {

--- a/src/hue-like-light-card.ts
+++ b/src/hue-like-light-card.ts
@@ -127,7 +127,7 @@ export class HueLikeLightCard extends LitElement implements LovelaceCard {
         if (this._config?.isInitialized != true)
             throw new Error('Config is not initialized.');
 
-        this._ctrl = new LightController(this._config.getEntities(), this._config.getDefaultColor());
+        this._ctrl = new LightController(this._config.getEntities(), this._config.getDefaultColor(), this._config.groupEntity);
         this._actionHandler = new ActionHandler(this._config, this._ctrl, this);
 
         // For theme color set background to null

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -30,6 +30,7 @@ export class HueLikeLightCardConfig implements HueLikeLightCardConfigInterface {
         this.entity = plainConfig.entity;
         this.entities = plainConfig.entities;
         this.area = plainConfig.area;
+        this.groupEntity = plainConfig.groupEntity;
         this._title = plainConfig.title;
         this.description = plainConfig.description;
         this.icon = plainConfig.icon;
@@ -187,6 +188,7 @@ export class HueLikeLightCardConfig implements HueLikeLightCardConfigInterface {
     public readonly entity?: string;
     public readonly entities?: string[] | ConfigEntityInterface[];
     public readonly area?: string;
+    public readonly groupEntity?: string;
     public get title() {
         return this._title;
     }

--- a/src/types/types-config.ts
+++ b/src/types/types-config.ts
@@ -185,6 +185,7 @@ export class SceneData {
 export interface HueLikeLightCardConfigInterface extends ConfigEntityInterface {
     readonly entities?: string[] | ConfigEntityInterface[];
     readonly area?: string;
+    readonly groupEntity?: string;
     readonly title?: string;
     readonly description?: string;
     readonly icon?: string;


### PR DESCRIPTION
If using the first-level on/off toggle, the hue integration will tell the hue bridge to turn off each light off/on separately, so the lights will not turn off/on at the exact same time.  If we call light on/off service with the hue integration's light group entity created for each room in the hue app, the lights will all turn off/on at the same time. 

This adds the `lightGroup` option to utilize this behavior for the first-level on/off toggle, while still allowing for the individual underlying lights (`entities`) to be specified for displaying on the Hue Screen. 