### PR TITLE
Add power meter entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,14 @@ Some of these options may not be in the latest version. Please always check the 
     <td>Support for the <a href="https://github.com/thomasloven/lovelace-card-mod">card-mod</a>.</td>
   </tr>
   <tr>
+    <td><code>powerEntity</code></td>
+    <td>string</td>
+    <td>no</td>
+    <td>1.12.0</td>
+    <td>-</td>
+    <td>Optional power sensor entity (e.g. <code>sensor.livingroom_power</code>) to show the current power consumption</td>
+  </tr>  
+  <tr>
     <td colspan="6">
       <i>* At least one of these options must be filled in. <b>Only entities of <code>light</code> domain and/or floors, areas and labels with <code>light</code> domain entities are supported.</b></i>
     </td>

--- a/src/controls/dialog.ts
+++ b/src/controls/dialog.ts
@@ -397,6 +397,16 @@ export class HueDialog extends IdLitElement {
         /* from HA 2026.5 - compensate for inner label margin */
         margin-inline-end: -0.5em;
     }
+    .hue-heading .power-value {
+        align-self: center;
+        margin-inline-end: 2px;
+        margin-top: -4px;
+        font-size: 14px;
+        font-weight: 500;
+        color: var(--hue-heading-text-color);
+        text-shadow: 0 1px 3px rgba(0,0,0,0.4);
+        white-space: nowrap;
+    }       
     .hue-heading .brightness-slider {
         width: 100%;
     }
@@ -746,6 +756,7 @@ export class HueDialog extends IdLitElement {
               ${cardTitle}
             </div>
             <div slot="actionItems">
+              ${this._config.powerEntity ? ViewUtils.createPowerDisplay(this._ctrl.hass, this._config.powerEntity) : nothing}
               ${ViewUtils.createSwitch(this._ctrl, this.onChangeHandler, this._config.switchOnScene)}
             </div>
             ${ViewUtils.createSlider(this._ctrl, this._config, this.onChangeHandler)}

--- a/src/controls/dialog.ts
+++ b/src/controls/dialog.ts
@@ -404,7 +404,6 @@ export class HueDialog extends IdLitElement {
         font-size: 14px;
         font-weight: 500;
         color: var(--hue-heading-text-color);
-        text-shadow: 0 1px 3px rgba(0,0,0,0.4);
         white-space: nowrap;
     }       
     .hue-heading .brightness-slider {

--- a/src/core/view-utils.ts
+++ b/src/core/view-utils.ts
@@ -87,7 +87,9 @@ export class ViewUtils {
 
         const display = value >= 1000
             ? `${(value / 1000).toFixed(1)} k${unit}`
-            : `${value.toFixed(1)} ${unit}`;
+            : value >= 10
+                ? `${Math.round(value)} ${unit}`
+                : `${value.toFixed(1)} ${unit}`;
 
         return html`<span class="power-value">${display}</span>`;
     }

--- a/src/core/view-utils.ts
+++ b/src/core/view-utils.ts
@@ -11,6 +11,7 @@ import { Color } from './colors/color';
 import { HaIcon, IHassWindow } from '../types/types-hass';
 import { SliderType } from '../types/types-config';
 import { HueMushroomSliderContainer } from '../controls/mushroom-slider-container';
+import { HomeAssistant } from 'custom-card-helpers';
 
 export class ViewUtils {
 
@@ -72,6 +73,23 @@ export class ViewUtils {
             .value=${ctrl.brightnessValue}
             @change=${(ev: Event) => ViewUtils.changed(ev, true, ctrl, onChange)}
         ></ha-slider>`;
+    }
+
+    public static createPowerDisplay(hass: HomeAssistant, powerEntityId: string | undefined) {
+        if (!powerEntityId) return nothing;
+        const state = hass?.states?.[powerEntityId];
+        if (!state || state.state === 'unavailable' || state.state === 'unknown')
+            return nothing;
+
+        const unit = state.attributes?.unit_of_measurement ?? 'W';
+        const value = parseFloat(state.state);
+        if (isNaN(value)) return nothing;
+
+        const display = value >= 1000
+            ? `${(value / 1000).toFixed(1)} k${unit}`
+            : `${value.toFixed(1)} ${unit}`;
+
+        return html`<span class="power-value">${display}</span>`;
     }
 
     private static changed(ev: Event, isSlider: boolean, ctrl: ILightContainer, onChange: Action, switchOnScene?: string) {

--- a/src/hue-like-light-card.ts
+++ b/src/hue-like-light-card.ts
@@ -318,6 +318,15 @@ export class HueLikeLightCard extends IdLitElement implements LovelaceCard {
         display:flex;
         overflow:auto;
     }
+    .power-value {
+        align-self: center;
+        margin-inline-end: 14px;
+        margin-top: -3px;
+        font-size: 13px;
+        font-weight: 500;
+        white-space: nowrap;
+        color: var(--hue-text-color);
+    }
     `;
 
     protected override updated(changedProps: PropertyValues): void {
@@ -474,6 +483,7 @@ export class HueLikeLightCard extends IdLitElement implements LovelaceCard {
                         <div class="desc">${description}</div>
                     </div>
                 </div>
+                ${this._config.powerEntity ? ViewUtils.createPowerDisplay(this._hass, this._config.powerEntity) : nothing}
                 ${showSwitch ? ViewUtils.createSwitch(this._ctrl, this.onChangeHandler, this._config.switchOnScene) : nothing}
             </div>
             ${ViewUtils.createSlider(this._ctrl, this._config, this.onChangeHandler)}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -98,6 +98,7 @@ export class HueLikeLightCardConfig extends HueLikeLightCardEntityConfig impleme
         this.label = plainConfig.label;
         this.groupEntity = plainConfig.groupEntity;
         this.description = plainConfig.description;
+        this.powerEntity = plainConfig.powerEntity;
         this.iconSize = HueLikeLightCardConfig.getIconSize(plainConfig.iconSize);
         this.showSwitch = HueLikeLightCardConfig.getBoolean(plainConfig.showSwitch, true);
         this.switchOnScene = plainConfig.switchOnScene;
@@ -310,6 +311,7 @@ export class HueLikeLightCardConfig extends HueLikeLightCardEntityConfig impleme
     public readonly hueBorders: boolean;
     public readonly apiId?: string;
     public readonly isVisible: boolean;
+    public readonly powerEntity?: string;
 
     /** Support for card-mod styling */
     public readonly style?: unknown;

--- a/src/types/types-config.ts
+++ b/src/types/types-config.ts
@@ -268,6 +268,7 @@ export interface HueLikeLightCardConfigInterface extends HueLikeLightCardEntityC
     readonly hueBorders?: boolean;
     readonly apiId?: string;
     readonly isVisible?: boolean;
+    readonly powerEntity?: string;
     /** Support for card-mod styling */
     readonly style?: unknown;
     readonly card_mod?: unknown;


### PR DESCRIPTION
For "smart" devices like Hue lights, it's obvious to determine or calculate their current power consumption.

If the devices themselves don't provide this value, it can usually be estimated quite accurately. There are already existing integrations for this, such as [PowerCalc](https://github.com/bramstroker/homeassistant-powercalc), which provide sensors for the calculated power consumption of individual lights or groups.

<img width="656" height="664" alt="image" src="https://github.com/user-attachments/assets/d5973747-2cbb-4851-a017-7f0d2e47efbc" />


Especially when a setup includes dozens of lights, an overview of the power consumption in each room is very helpful.
<img width="896" height="571" alt="image" src="https://github.com/user-attachments/assets/f332d440-d97a-4666-b156-f3f90879546e" />
This sensor value can now be displayed using the `powerEntity` property.

I come from the .NET world and am not a frontend developer. Therefore, it's quite possible that I haven't implemented everything perfectly with the styles. Improvements and suggestions for this pull request are therefore very welcome!