### PR TITLE
Add optional 'count' property to entity config

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,13 @@ Some of these options may not be in the latest version. Please always check the 
     <td>1.8.0</td>
     <td>Light icon shown on <a href="#hue-screen">Hue Screen</a></td>
   </tr>
+  <tr>
+    <td><code>count</code></td>
+    <td>number</td>
+    <td>no</td>
+    <td>1.12.0</td>
+    <td>How many lights this entity should count as in the card statistics (default <code>1</code>). Set to <code>0</code> to hide the entity from the &quot;X of Y lights on&quot; <code>description</code> and from the <a href="#automatic-icon">automatic icon</a> selection — the entity is still controlled by the card, just not counted. Values greater than <code>1</code> can be used when a single HA entity represents a light group of multiple physical bulbs. Negative values are clamped to <code>0</code>.</td>
+  </tr>
 </table>
 
 ### Click & Hold configuration

--- a/src/core/area-light-controller.ts
+++ b/src/core/area-light-controller.ts
@@ -22,13 +22,15 @@ export class AreaLightController implements ILightContainer, INotifyGeneric<Ligh
     private _lights: LightController[];
     private _lightsFeatures: LightFeaturesCombined;
     private _defaultColor: Color;
+    private _countMap: Record<string, number>;
 
-    public constructor(entity_ids: string[], defaultColor: Color, lightGroupEntityId?: string) {
+    public constructor(entity_ids: string[], defaultColor: Color, lightGroupEntityId?: string, countMap?: Record<string, number>) {
         // we need at least one
         if (!entity_ids.length)
             throw new Error('No entity specified.');
 
         this._defaultColor = defaultColor;
+        this._countMap = countMap || {};
         this._lights = entity_ids.map(e => GlobalLights.getLightContainer(e));
         this._lightsFeatures = new LightFeaturesCombined(() => this._lights.map(l => l.features));
         if (lightGroupEntityId) {
@@ -44,10 +46,17 @@ export class AreaLightController implements ILightContainer, INotifyGeneric<Ligh
     }
 
     /**
-     * @returns count of registered lights.
+     * @returns count of registered lights (adjusted by configured count values).
      */
     public get count() {
-        return this._lights.length;
+        return this._lights.reduce((sum, l) => sum + this.getLightCount(l), 0);
+    }
+
+    /**
+     * @returns configured count value for given light (default 1).
+     */
+    private getLightCount(light: LightController): number {
+        return this._countMap[light.getEntityId()] ?? 1;
     }
 
     /**
@@ -193,10 +202,10 @@ export class AreaLightController implements ILightContainer, INotifyGeneric<Ligh
 
     public getIcon(): string {
         if (this._lights.length == 1) {
-            return this._lights[0].getIcon() || IconHelper.getIcon(1);
+            return this._lights[0].getIcon() || IconHelper.getIcon(this.count);
         }
 
-        return IconHelper.getIcon(this._lights.length);
+        return IconHelper.getIcon(this.count);
     }
 
     public getTitle() {
@@ -221,11 +230,11 @@ export class AreaLightController implements ILightContainer, INotifyGeneric<Ligh
      * @returns localized description of how many lights are on.
      */
     public getDescription(description: string | undefined): IHassTextTemplate {
-        const total = this._lights.length;
+        const total = this.count;
         let lit = 0;
         this._lights.forEach(l => {
             if (l.isOn()) {
-                lit++;
+                lit += this.getLightCount(l);
             }
         });
 

--- a/src/hue-like-light-card.ts
+++ b/src/hue-like-light-card.ts
@@ -140,7 +140,8 @@ export class HueLikeLightCard extends IdLitElement implements LovelaceCard {
         if (this._config?.isInitialized != true)
             throw new Error('Config is not initialized.');
 
-        this._ctrl = new AreaLightController(this._config.getEntities().getIdList(), this._config.getDefaultColor(), this._config.groupEntity);
+        const entities = this._config.getEntities();
+        this._ctrl = new AreaLightController(entities.getIdList(), this._config.getDefaultColor(), this._config.groupEntity, entities.getCountMap());
         this._actionHandler = new ActionHandler(this._config, this._ctrl, this);
 
         // For theme color set background to null

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -20,6 +20,7 @@ declare type EntityRelations = {
 export class HueLikeLightCardEntityConfig implements HueLikeLightCardEntityConfigInterface {
     protected _title?: string;
     protected _icon?: string;
+    protected _count?: number;
 
     public constructor(plainConfigOrEntityId: HueLikeLightCardEntityConfigInterface | string) {
         if (typeof plainConfigOrEntityId == "string"){
@@ -29,6 +30,7 @@ export class HueLikeLightCardEntityConfig implements HueLikeLightCardEntityConfi
             this.entity = plainConfigOrEntityId.entity!;
             this._title = plainConfigOrEntityId.title;
             this._icon = plainConfigOrEntityId.icon;
+            this._count = plainConfigOrEntityId.count;
         }
     }
 
@@ -38,6 +40,10 @@ export class HueLikeLightCardEntityConfig implements HueLikeLightCardEntityConfi
     }
     public get icon() {
         return this._icon;
+    };
+    public get count(): number {
+        if (this._count == null) return 1;
+        return this._count >= 0 ? this._count : 0;
     };
 
     /**
@@ -73,6 +79,20 @@ export class HueLikeLightCardEntityConfigCollection {
 
     public getIdList(): string[] {
         return this._entityList.map(e => e); // map is creating new array
+    }
+
+    /**
+     * @returns map of entity_id to configured count value (only entries that differ from the default of 1).
+     */
+    public getCountMap(): Record<string, number> {
+        const result: Record<string, number> = {};
+        for (const entityId of this._entityList) {
+            const count = this._entityMap[entityId].count;
+            if (count !== 1) {
+                result[entityId] = count;
+            }
+        }
+        return result;
     }
 
     public get length() {

--- a/src/types/types-config.ts
+++ b/src/types/types-config.ts
@@ -277,4 +277,5 @@ export interface HueLikeLightCardEntityConfigInterface {
     readonly entity?: string;
     readonly title?: string;
     readonly icon?: string;
+    readonly count?: number;
 }


### PR DESCRIPTION
This pull request addresses two different use cases.

Often, entities are added to a room that are not counted as lights and should not be included in the corresponding text in the card. Examples include the activation of a motion detector, fans, or other devices.
<img width="541" height="345" alt="Screenshot 2026-05-28 173140+" src="https://github.com/user-attachments/assets/f9b1e265-b4d1-4bc0-bd26-1b457615346a" />

These entities can now be excluded from the count by simply setting 'count: 0'.
<img width="496" height="97" alt="image" src="https://github.com/user-attachments/assets/6f3f6cff-b41b-4e22-9bcc-e41acb212b5e" />

<img width="540" height="338" alt="image" src="https://github.com/user-attachments/assets/8e46a1d8-5244-490d-a728-6faea1835dba" />

\
\
\
The other (less common) use case involves light groups. To keep the card dialog uncluttered, several lights can be grouped together, and only the group itself can be added. 
<img width="539" height="332" alt="Screenshot 2026-05-28 173406+" src="https://github.com/user-attachments/assets/11925b27-92b2-4f87-83c4-d6af3b003a0d" />
With the count property set, you can now count each individual bulb.
<img width="315" height="138" alt="image" src="https://github.com/user-attachments/assets/04c28866-8f34-41f0-8d21-c4c50688e26f" />

<img width="551" height="351" alt="image" src="https://github.com/user-attachments/assets/5c50355f-f99c-484a-885e-7094c12d1aa7" />
